### PR TITLE
feat: allow multiple patches per plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,16 @@ dir: (default path)
 $ mkdir ~/.config/nvim/patches
 ```
 
-Here you could add your patches. Two considerations:
+Here you could add your patches.
 
-1. Only **one file** per plugin.
-2. The name of the patch should match the repository name (more precisely, the
-   directory name inside the Lazy root folder) and the file extension must be
-   `.patch`. e.g.: `nvim-treesitter.patch`
+- If you need just one patch for a plugin, you can save it in the
+  `patches` directory. The name of the patch should match the repository name
+  (more precisely, the directory name inside the Lazy root folder), and the
+  file extension must be `.patch`. E.g.: `nvim-treesitter.patch` or
+  `telescope.nvim.patch`.
+- If you need multiple patches for a plugin, you can create a subdirectory
+  with a name matching the plugin repository name and save your patches inside
+  that directory. E.g.: `nvim-treesitter/1.patch` or `telescope.nvim/1.patch`.
 
 ### ⚙️ Configuration
 

--- a/doc/lazy-local-patcher.nvim.txt
+++ b/doc/lazy-local-patcher.nvim.txt
@@ -61,12 +61,16 @@ dir: (default path)
     $ mkdir ~/.config/nvim/patches
 <
 
-Here you could add your patches. Two considerations:
+Here you could add your patches.
 
-1. Only **one file** per plugin.
-2. The name of the patch should match the repository name (more precisely, the
-directory name inside the Lazy root folder) and the file extension must be
-`.patch`. e.g.: `nvim-treesitter.patch`
+- If you need just one patch for a plugin, you can save it in the
+  `patches` directory. The name of the patch should match the repository name
+  (more precisely, the directory name inside the Lazy root folder), and the
+  file extension must be `.patch`. E.g.: `nvim-treesitter.patch` or
+  `telescope.nvim.patch`.
+- If you need multiple patches for a plugin, you can create a subdirectory
+  with a name matching the plugin repository name and save your patches inside
+  that directory. E.g.: `nvim-treesitter/1.patch` or `telescope.nvim/1.patch`.
 
 
 CONFIGURATION                          *lazy-local-patcher.nvim-configuration*

--- a/lua/lazy-local-patcher/patcher.lua
+++ b/lua/lazy-local-patcher/patcher.lua
@@ -44,12 +44,18 @@ end
 
 ---@param opts LazyLocalPatcher.Options
 function M.apply_all(opts)
+  local patches = {}
   for patch in vim.fs.dir(opts.patches_path, { depth = 2 }) do
     if patch:match("%.patch$") ~= nil then
-      local patch_path = opts.patches_path .. "/" .. patch
-      local repo_path = opts.lazy_path .. "/" .. patch:gsub("/.*", ""):gsub("%.patch$", "")
-      M.apply_patch(patch, patch_path, repo_path)
+      table.insert(patches, patch)
     end
+  end
+  table.sort(patches)
+
+  for _, patch in ipairs(patches) do
+    local patch_path = opts.patches_path .. "/" .. patch
+    local repo_path = opts.lazy_path .. "/" .. patch:gsub("/.*", ""):gsub("%.patch$", "")
+    M.apply_patch(patch, patch_path, repo_path)
   end
 end
 

--- a/lua/lazy-local-patcher/patcher.lua
+++ b/lua/lazy-local-patcher/patcher.lua
@@ -44,10 +44,10 @@ end
 
 ---@param opts LazyLocalPatcher.Options
 function M.apply_all(opts)
-  for patch in vim.fs.dir(opts.patches_path) do
+  for patch in vim.fs.dir(opts.patches_path, { depth = 2 }) do
     if patch:match("%.patch$") ~= nil then
       local patch_path = opts.patches_path .. "/" .. patch
-      local repo_path = opts.lazy_path .. "/" .. patch:gsub("%.patch", "")
+      local repo_path = opts.lazy_path .. "/" .. patch:gsub("/.*", ""):gsub("%.patch$", "")
       M.apply_patch(patch, patch_path, repo_path)
     end
   end
@@ -55,8 +55,8 @@ end
 
 ---@param opts LazyLocalPatcher.Options
 function M.restore_all(opts)
-  for patch in vim.fs.dir(opts.patches_path) do
-    if patch:match("%.patch$") ~= nil then
+  for patch, type in vim.fs.dir(opts.patches_path) do
+    if patch:match("%.patch$") ~= nil or type == "directory" then
       local repo_path = opts.lazy_path .. "/" .. patch:gsub("%.patch", "")
       M.restore_repo(patch, repo_path)
     end


### PR DESCRIPTION
Having only one patch per plugin is inconvenient in case there are changes related to different open PRs which may be merged or rejected by plugin author in any order and time.

Probably elements returned by vim.fs.dir must be sorted to ensure consistent patch apply order, but I've tried to keep changes to minimal in this PR, so this can be added later.

P.S. You probably need to add some sort of script/Makefile/etc. with panvimdoc command.